### PR TITLE
✨ Pub/Sub topics and BigQuery tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # 🔖 Changelog
 
 ## Unreleased
+
+Features:
+
+- Implement the first version of the module, managing Pub/Sub topics and BigQuery tables for raw events.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # Terraform module for Pub/Sub topics management
+
+This Terraform module manages a Causa workspace's event topics, created as Pub/Sub topics. Optionally, it can also manage the data warehouse for those events, in the form of BigQuery tables. The module relies on the [`ProjectWriteConfigurations`](https://github.com/causa-io/workspace-module-core#projectwriteconfigurations) and [`GooglePubSubWriteTopics`](https://github.com/causa-io/workspace-module-google#googlepubsubwritetopics) infrastructure processors to generate the configuration for the topics and BigQuery tables.
+
+## ➕ Requirements
+
+This module depends on the [google Terraform provider](https://registry.terraform.io/providers/hashicorp/google/latest).
+
+## 🎉 Installation
+
+Copy the following in your Terraform configuration, and run `terraform init`:
+
+```terraform
+module "my_service" {
+  source  = "causa-io/event-topics-pubsub/google"
+  version = "<insert the most recent version number here>"
+
+  # The path to the generated configuration file for the infrastructure project.
+  infrastructure_configuration_file = "${local.project_configurations_directory}/infrastructure.json"
+  # The path to the generated topics configurations.
+  topics_directory                  = "${local.causa_directory}/pubsub-topics"
+}
+```
+
+## ✨ Features
+
+### Pub/Sub topics
+
+A Pub/Sub topic is created and managed for each topic configuration file written by the [`GooglePubSubWriteTopics`](https://github.com/causa-io/workspace-module-google#googlepubsubwritetopics) processor at the location set in the `topics_directory` Terraform variable. The event topics are found in the workspace as defined in the `events.topics` configuration.
+
+### Raw BigQuery tables
+
+If the `google.pubSub.bigQueryStorage.rawEventsDatasetId` configuration (or the `bigquery_raw_events_dataset` Terraform variable) is set, a BigQuery table will automatically be created for each topic, and a Pub/Sub BigQuery subscription will be configured to pipe all events to the table.
+
+### Deletion protection
+
+The `deletion_protection` Terraform variable defaults to `true` and protects BigQuery tables against deletion. It must be set to `false` to be able to delete the tables.

--- a/bigquery-raw-tables.tf
+++ b/bigquery-raw-tables.tf
@@ -1,0 +1,105 @@
+# The dataset for raw event tables piped directly from Pub/Sub to BigQuery.
+resource "google_bigquery_dataset" "raw_events" {
+  count = local.bigquery_raw_events_dataset != null ? 1 : 0
+
+  project               = local.gcp_project_id
+  dataset_id            = local.bigquery_raw_events_dataset
+  friendly_name         = "Raw events from Pub/Sub"
+  description           = "Dataset containing the raw events from Pub/Sub."
+  location              = local.bigquery_location
+  max_time_travel_hours = 48
+}
+
+# The permissions for Pub/Sub to write to BigQuery.
+resource "google_bigquery_dataset_iam_member" "pubsub_raw_events_editor" {
+  count = local.bigquery_raw_events_dataset != null ? 1 : 0
+
+  project    = local.gcp_project_id
+  dataset_id = google_bigquery_dataset.raw_events[0].dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_bigquery_dataset_iam_member" "pubsub_raw_events_metadata_viewer" {
+  count = local.bigquery_raw_events_dataset != null ? 1 : 0
+
+  project    = local.gcp_project_id
+  dataset_id = google_bigquery_dataset.raw_events[0].dataset_id
+  role       = "roles/bigquery.metadataViewer"
+  member     = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+# The BigQuery tables for raw events.
+# They all have the same schema as Pub/Sub writes the entire payload in the `data` field.
+resource "google_bigquery_table" "raw_events" {
+  for_each = local.bigquery_raw_events_dataset != null ? local.topic_configurations : {}
+
+  project       = local.gcp_project_id
+  dataset_id    = google_bigquery_dataset.raw_events[0].dataset_id
+  table_id      = each.value.bigQueryTableName
+  description   = "Table for raw ${each.key} events."
+  friendly_name = each.key
+
+  schema = jsonencode([
+    {
+      mode        = "NULLABLE"
+      name        = "subscription_name"
+      type        = "STRING"
+      description = "The name of the Pub/Sub subscription."
+    },
+    {
+      mode        = "NULLABLE"
+      name        = "message_id"
+      type        = "STRING"
+      description = "The ID of the Pub/Sub messsage."
+    },
+    {
+      mode        = "NULLABLE"
+      name        = "publish_time"
+      type        = "TIMESTAMP"
+      description = "The time of publishing of the message."
+    },
+    {
+      mode        = "REQUIRED"
+      name        = "data"
+      type        = "STRING"
+      description = "The JSON-encoded string containing the payload of the event."
+    },
+    {
+      mode        = "NULLABLE"
+      name        = "attributes"
+      type        = "STRING"
+      description = "The JSON-encoded string containing the dictionary of attributes for the message."
+    }
+  ])
+
+  time_partitioning {
+    field = "publish_time"
+    type  = "DAY"
+  }
+
+  deletion_protection = var.deletion_protection
+}
+
+# The subscriptions automatically piping Pub/Sub events to BigQuery tables.
+resource "google_pubsub_subscription" "bigquery" {
+  for_each = google_bigquery_table.raw_events
+
+  project = local.gcp_project_id
+  name    = "bq-${each.key}"
+  topic   = google_pubsub_topic.topic[each.key].id
+
+  bigquery_config {
+    table          = "${each.value.project}:${each.value.dataset_id}.${each.value.table_id}"
+    write_metadata = true
+  }
+
+  expiration_policy {
+    ttl = ""
+  }
+
+  depends_on = [
+    google_bigquery_dataset_iam_member.pubsub_raw_events_editor,
+    google_bigquery_dataset_iam_member.pubsub_raw_events_metadata_viewer,
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,21 @@ locals {
   # Project configuration from the JSON file.
   configuration = yamldecode(file(var.infrastructure_configuration_file))
 
-  conf_google         = try(local.configuration.google, tomap({}))
-  conf_google_project = try(local.conf_google.project, null)
-  conf_google_region  = try(local.conf_google.region, null)
+  conf_google                      = try(local.configuration.google, tomap({}))
+  conf_google_project              = try(local.conf_google.project, null)
+  conf_google_region               = try(local.conf_google.region, null)
+  conf_pubsub                      = try(local.conf_google.pubSub, tomap({}))
+  conf_bigquery_storage            = try(local.conf_pubsub.bigQueryStorage, tomap({}))
+  conf_bigquery_location           = try(local.conf_bigquery_storage.location, null)
+  conf_bigquery_raw_events_dataset = try(local.conf_bigquery_storage.rawEventsDatasetId, tomap({}))
 
   # Configuration with variable overrides.
-  gcp_project_id = coalesce(var.gcp_project_id, local.conf_google_project)
-  gcp_region     = coalesce(var.gcp_region, local.conf_google_region)
+  gcp_project_id              = coalesce(var.gcp_project_id, local.conf_google_project)
+  gcp_region                  = coalesce(var.gcp_region, local.conf_google_region)
+  bigquery_location           = try(coalesce(var.bigquery_location, local.conf_bigquery_location), null)
+  bigquery_raw_events_dataset = try(coalesce(var.bigquery_raw_events_dataset, local.conf_bigquery_raw_events_dataset), null)
+}
+
+data "google_project" "project" {
+  project_id = local.gcp_project_id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,12 @@
+locals {
+  # Project configuration from the JSON file.
+  configuration = yamldecode(file(var.infrastructure_configuration_file))
 
+  conf_google         = try(local.configuration.google, tomap({}))
+  conf_google_project = try(local.conf_google.project, null)
+  conf_google_region  = try(local.conf_google.region, null)
+
+  # Configuration with variable overrides.
+  gcp_project_id = coalesce(var.gcp_project_id, local.conf_google_project)
+  gcp_region     = coalesce(var.gcp_region, local.conf_google_region)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,7 @@
-
+output "topic_ids" {
+  description = "A map where keys are topic full names and values are Pub/Sub topic IDs."
+  value = {
+    for topic_full_name, topic in google_pubsub_topic.topic :
+    topic_full_name => topic.id
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,8 @@ output "topic_ids" {
     topic_full_name => topic.id
   }
 }
+
+output "bigquery_events_raw_dataset_id" {
+  description = "The ID of the BigQuery dataset containing the raw Pub/Sub messages for the event topics."
+  value       = local.bigquery_raw_events_dataset != null ? google_bigquery_dataset.raw_events[0].dataset_id : null
+}

--- a/topics.tf
+++ b/topics.tf
@@ -1,0 +1,24 @@
+locals {
+  topic_configuration_files = [
+    for configuration in fileset(var.topics_directory, "*.{json,yaml}") :
+    yamldecode(file("${var.topics_directory}/${configuration}"))
+  ]
+  topic_configurations = {
+    for configuration in local.topic_configuration_files :
+    configuration.id => configuration
+  }
+}
+
+# The Pub/Sub topic for each configuration.
+resource "google_pubsub_topic" "topic" {
+  for_each = local.topic_configurations
+
+  project = local.gcp_project_id
+  name    = each.value.id
+
+  message_storage_policy {
+    allowed_persistence_regions = [
+      local.gcp_region
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,21 @@ variable "gcp_region" {
   description = "The GCP region in which resources will be placed. Defaults to the `google.region` configuration."
   default     = null
 }
+
+variable "bigquery_location" {
+  type        = string
+  description = "The location of the BigQuery datasets. Defaults to the `google.pubSub.bigQueryStorage.location` configuration."
+  default     = null
+}
+
+variable "bigquery_raw_events_dataset" {
+  type        = string
+  description = "The ID of the BigQuery dataset containing the raw Pub/Sub messages for event topics. Defaults to the `google.pubSub.bigQueryStorage.rawEventsDatasetId` configuration."
+  default     = null
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Whether the BigQuery tables are protected against deletion. Defaults to `true`."
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,21 @@
+variable "infrastructure_configuration_file" {
+  type        = string
+  description = "The path to the configuration file for the infrastructure project. It should be in JSON or YAML."
+}
 
+variable "topics_directory" {
+  type        = string
+  description = "The path to the directory containing the generated topic configurations."
+}
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID in which resources will be placed. Defaults to the `google.project` configuration."
+  default     = null
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "The GCP region in which resources will be placed. Defaults to the `google.region` configuration."
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,1 +1,8 @@
-
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.75.0, < 5.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the first version of the module, managing Pub/Sub topics and the corresponding BigQuery tables for raw events.

### Commits

- ➕ Depend on the google Terraform provider
- ✨ Define the Pub/Sub topic for each configuration
- ✨ Define the BigQuery tables for raw events
- 📝 Update changelog
- 📝 Document the module