### PR TITLE
💥 Better BigQuery raw events column types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Use `JSON` and `BYTES` by default for BigQuery raw events `data` and `attributes` columns. Types can be overridden using the `bigquery_raw_events_data_type` and `bigquery_raw_events_attributes_type` variables.
+
 ## v0.1.2 (2024-08-30)
 
 Chores:

--- a/bigquery-raw-tables.tf
+++ b/bigquery-raw-tables.tf
@@ -62,13 +62,13 @@ resource "google_bigquery_table" "raw_events" {
     {
       mode        = "REQUIRED"
       name        = "data"
-      type        = "STRING"
+      type        = local.bigquery_raw_events_data_type
       description = "The JSON-encoded string containing the payload of the event."
     },
     {
       mode        = "NULLABLE"
       name        = "attributes"
-      type        = "STRING"
+      type        = var.bigquery_raw_events_attributes_type
       description = "The JSON-encoded string containing the dictionary of attributes for the message."
     }
   ])

--- a/main.tf
+++ b/main.tf
@@ -9,12 +9,15 @@ locals {
   conf_bigquery_storage            = try(local.conf_pubsub.bigQueryStorage, tomap({}))
   conf_bigquery_location           = try(local.conf_bigquery_storage.location, null)
   conf_bigquery_raw_events_dataset = try(local.conf_bigquery_storage.rawEventsDatasetId, tomap({}))
+  conf_events                      = try(local.configuration.events, tomap({}))
+  conf_events_format               = try(local.conf_events.format, null)
 
   # Configuration with variable overrides.
-  gcp_project_id              = coalesce(var.gcp_project_id, local.conf_google_project)
-  gcp_region                  = coalesce(var.gcp_region, local.conf_google_region)
-  bigquery_location           = try(coalesce(var.bigquery_location, local.conf_bigquery_location), null)
-  bigquery_raw_events_dataset = try(coalesce(var.bigquery_raw_events_dataset, local.conf_bigquery_raw_events_dataset), null)
+  gcp_project_id                = coalesce(var.gcp_project_id, local.conf_google_project)
+  gcp_region                    = coalesce(var.gcp_region, local.conf_google_region)
+  bigquery_location             = try(coalesce(var.bigquery_location, local.conf_bigquery_location), null)
+  bigquery_raw_events_dataset   = try(coalesce(var.bigquery_raw_events_dataset, local.conf_bigquery_raw_events_dataset), null)
+  bigquery_raw_events_data_type = coalesce(var.bigquery_raw_events_data_type, local.conf_events_format == "json" ? "JSON" : "BYTES")
 }
 
 data "google_project" "project" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,15 @@ variable "deletion_protection" {
   description = "Whether the BigQuery tables are protected against deletion. Defaults to `true`."
   default     = true
 }
+
+variable "bigquery_raw_events_data_type" {
+  type        = string
+  description = "The type of the `data` column in the raw events BigQuery tables. Can be `STRING`, `BYTES`, or `JSON`. Defaults to `JSON` if the `events.format` configuration is `json`, or `BYTES` otherwise."
+  default     = null
+}
+
+variable "bigquery_raw_events_attributes_type" {
+  type        = string
+  description = "The type of the `attributes` column in the raw events BigQuery tables. Can be `JSON` or `STRING`. Defaults to `JSON`."
+  default     = "JSON"
+}


### PR DESCRIPTION
This uses `JSON` for the `attributes` column by default, and `JSON` or `BYTES` for `data`, which eases processing the data in the BigQuery tables.
Variables are exposed for backward compatibility, such that `STRING` types can be kept if needed.
