### PR TITLE
🔖 Prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.0 (2025-08-27)
+
 Breaking changes:
 
 - Use `JSON` and `BYTES` by default for BigQuery raw events `data` and `attributes` columns. Types can be overridden using the `bigquery_raw_events_data_type` and `bigquery_raw_events_attributes_type` variables.


### PR DESCRIPTION
Breaking changes:

- Use `JSON` and `BYTES` by default for BigQuery raw events `data` and `attributes` columns. Types can be overridden using the `bigquery_raw_events_data_type` and `bigquery_raw_events_attributes_type` variables.